### PR TITLE
fix: Fix incorrect printing of total tasks

### DIFF
--- a/src/main/java/anonbot/task/TaskManager.java
+++ b/src/main/java/anonbot/task/TaskManager.java
@@ -59,7 +59,7 @@ public class TaskManager {
         Task newTask = createTask(taskDescription, taskType, totalTasksCreated, false);
         System.out.println("Alright. I have added this task: ");
         newTask.printTask();
-        System.out.println("Now you have " + totalTasksCreated + " tasks in the list.");
+        System.out.println("Now you have " + taskList.size() + " tasks in the list.");
     }
 
     /**


### PR DESCRIPTION
the `totalTasksCreated` was used previously as the delete functionality was not introduced, and so the total number of tasks was the number of the last item on the list. When delete was introduced, it was decided that all new tasks created will have a unique Task ID. Hence, there is now a need to separate check the number of active tasks in the list.